### PR TITLE
dp to px converter extension

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+        freeCompilerArgs = ["-Xcontext-receivers"]
     }
 }
 

--- a/app/src/main/java/com/mobillium/klobalx/MainActivity.kt
+++ b/app/src/main/java/com/mobillium/klobalx/MainActivity.kt
@@ -3,6 +3,7 @@ package com.mobillium.klobalx
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.TextView
+import com.mobillium.klobalx.nativeext.dpInPixels
 import com.mobillium.klobalx.nativeext.gone
 
 class MainActivity : AppCompatActivity() {
@@ -13,5 +14,13 @@ class MainActivity : AppCompatActivity() {
         findViewById<TextView>(R.id.textview_welcome)?.run {
             gone()
         }
+
+        //dp-to-px conversion
+        val intDpValue = 5
+        intDpValue.dpInPixels()
+        val floatDpValue = 5f
+        floatDpValue.dpInPixels()
+        val doubleDpValue = 5.00
+        doubleDpValue.dpInPixels()
     }
 }

--- a/klobalx/build.gradle
+++ b/klobalx/build.gradle
@@ -27,6 +27,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+        freeCompilerArgs = ["-Xcontext-receivers"]
     }
 }
 

--- a/klobalx/src/main/java/com/mobillium/klobalx/nativeext/MetricExt.kt
+++ b/klobalx/src/main/java/com/mobillium/klobalx/nativeext/MetricExt.kt
@@ -1,0 +1,18 @@
+package com.mobillium.klobalx.nativeext
+
+import android.content.Context
+import androidx.fragment.app.Fragment
+
+context(Context)
+fun Number.dpInPixels(): Int {
+    return convertDpToPixels(this@Context, this)
+}
+
+context(Fragment)
+fun Number.dpInPixels(): Int {
+    return convertDpToPixels(requireContext(), this)
+}
+
+private fun convertDpToPixels(context: Context, dp: Number): Int {
+    return (dp.toFloat() * context.resources.displayMetrics.density).toInt()
+}


### PR DESCRIPTION
**Pre-Not: Açıklamada bulunan 'Context Receiver'daki context kelimesi Android SDK bağlamındaki context anlamına gelmiyor** 


`context(Context)
fun Number.dpInPixels(): Int {
//conversion op
}`

Burda gördüğünüz fonksiyon Kotlin'de şu an experimental bir feature olan  _**Context Receiver**_'ı kullanıyor. Fonksiyonun deklarasyonun başına gelen `context(T)` syntax'ı ile sağlanır. Bu şu anlama gelir: "İlgili fonksiyon, yalnızca **_T_** tipindeki bir _**scope**_'un içinde çağrılabilir. 

**Neden?**

Conversion işlemi sırasında **Statik kaynak olan `Resources.getSystem()` yerine Context'e bağlı dinamik resource'a erişmek istiyoruz**. Yani bir context'e ihtiyacımız var. İşte bu noktada Context Receiver sayesinde syntax'da basitleşme sağlayabiliyoruz: `15.toPx(context)` yerine bir android context scope'unda (Mesela Activity) direkt olarak `15.toPx()` şeklinde çağırabiliyoruz.

- Ben verbose fonksiyon ve değişken isimlerini seviyorum. O yüzden adını **dpInPixels** koydum. Düşünebiliriz :)
- Property extension'ı olarak da uygulanabilir. `15.toPx()` yerine `15.toPx`. Context Receiver bunu da destekliyor.

